### PR TITLE
Allow custom serial device path via editable combo box

### DIFF
--- a/winkeyerserial/__main__.py
+++ b/winkeyerserial/__main__.py
@@ -170,8 +170,10 @@ class WinKeyer(QtWidgets.QMainWindow):
             self.comboBox_device.setItemData(index, serialport.description)
             self.device = serialport.device
             self.settings_dict["device"] = self.device
-        self.comboBox_device.currentIndexChanged.connect(self.change_serial)
+        self.comboBox_device.setEditable(True)
         self.loadsaved()
+        self.comboBox_device.currentIndexChanged.connect(self.change_serial)
+        self.comboBox_device.lineEdit().editingFinished.connect(self.change_serial)
 
     def change_serial(self):
         """
@@ -235,7 +237,11 @@ class WinKeyer(QtWidgets.QMainWindow):
         Opens the serial port and sets its parameters
         """
         self.outputbox.clear()
-        self.comboBox_device.setCurrentIndex(self.comboBox_device.findText(self.device))
+        index = self.comboBox_device.findText(self.device)
+        if index >= 0:
+            self.comboBox_device.setCurrentIndex(index)
+        else:
+            self.comboBox_device.setCurrentText(self.device)
         try:
             if self.port:
                 self.port.close()


### PR DESCRIPTION
The device combo box previously only listed ports discovered by comports(),
making it impossible to use virtual ports created by tools like socat.

Changes:
- Made comboBox_device editable so any device path can be typed manually
- Connected editingFinished instead of editTextChanged to avoid repeated
  connection attempts while typing
- Moved signal connections to after loadsaved() to prevent spurious
  change_serial calls during startup

Use case: bridging a network-connected WinKeyer emulator to a local
virtual serial port via socat.