### PR TITLE
Fix startup and custom device

### DIFF
--- a/winkeyerserial/__main__.py
+++ b/winkeyerserial/__main__.py
@@ -170,8 +170,10 @@ class WinKeyer(QtWidgets.QMainWindow):
             self.comboBox_device.setItemData(index, serialport.description)
             self.device = serialport.device
             self.settings_dict["device"] = self.device
-        self.comboBox_device.currentIndexChanged.connect(self.change_serial)
+        self.comboBox_device.setEditable(True)
         self.loadsaved()
+        self.comboBox_device.currentIndexChanged.connect(self.change_serial)
+        self.comboBox_device.lineEdit().editingFinished.connect(self.change_serial)
 
     def change_serial(self):
         """
@@ -235,7 +237,11 @@ class WinKeyer(QtWidgets.QMainWindow):
         Opens the serial port and sets its parameters
         """
         self.outputbox.clear()
-        self.comboBox_device.setCurrentIndex(self.comboBox_device.findText(self.device))
+        index = self.comboBox_device.findText(self.device)
+        if index >= 0:
+            self.comboBox_device.setCurrentIndex(index)
+        else:
+            self.comboBox_device.setCurrentText(self.device)
         try:
             if self.port:
                 self.port.close()

--- a/winkeyerserial/__main__.py
+++ b/winkeyerserial/__main__.py
@@ -170,8 +170,10 @@ class WinKeyer(QtWidgets.QMainWindow):
             self.comboBox_device.setItemData(index, serialport.description)
             self.device = serialport.device
             self.settings_dict["device"] = self.device
-        self.comboBox_device.currentIndexChanged.connect(self.change_serial)
+        self.comboBox_device.setEditable(True)
         self.loadsaved()
+        self.comboBox_device.currentIndexChanged.connect(self.change_serial)
+        self.comboBox_device.lineEdit().editingFinished.connect(self.change_serial)
 
     def change_serial(self):
         """
@@ -235,7 +237,13 @@ class WinKeyer(QtWidgets.QMainWindow):
         Opens the serial port and sets its parameters
         """
         self.outputbox.clear()
-        self.comboBox_device.setCurrentIndex(self.comboBox_device.findText(self.device))
+        self.comboBox_device.blockSignals(True)
+        index = self.comboBox_device.findText(self.device)
+        if index >= 0:
+            self.comboBox_device.setCurrentIndex(index)
+        else:
+            self.comboBox_device.setCurrentText(self.device)
+        self.comboBox_device.blockSignals(False)
         try:
             if self.port:
                 self.port.close()
@@ -442,13 +450,13 @@ class WinKeyer(QtWidgets.QMainWindow):
             if self.port.in_waiting:
                 byte = self.port.read(1)
                 if (byte[0] & b"\xc0"[0]) == b"\xc0"[0]:  # Status Change
-                    # print(f"Status Change: {byte}")
                     pass
                 elif (byte[0] & b"\xc0"[0]) == b"\x80"[0]:  # speed pot change
                     self.potspeed(byte[0])
                 else:  # process echoback character
-                    # print(byte.decode(), end="", flush=True)
-                    self.outputbox.insertPlainText(f"{byte.decode()}")
+                    if 0x20 <= byte[0] <= 0x7E:
+                        # print(byte.decode(), end="", flush=True)
+                        self.outputbox.insertPlainText(f"{byte.decode()}")
         except:
             self.host_init()  # Some one may have unplugged the keyer.
 


### PR DESCRIPTION
This PR fixes three bugs found during testing on Linux with a network-connected 
WinKeyer emulator (TeensyMaestro Community Edition).

**1. Re-entrant host_init() calls during startup**
The original code connected `currentIndexChanged` before calling `loadsaved()`. 
This caused `change_serial()` -> `host_init()` to fire during startup, resulting 
in `host_open()` being called twice. On hardware with audible feedback this is 
clearly noticeable as a double connection sound. Fixed by moving signal 
connections after `loadsaved()` and wrapping the `setCurrentIndex` call in 
`blockSignals(True/False)`.

**2. Editable device path**
The combo box only listed ports discovered by `comports()`, making it impossible 
to use virtual ports created by tools like `socat`. Fixed by making the combo box 
editable and connecting `editingFinished` (fires on Enter/focus loss) instead of 
`editTextChanged` (fires on every keystroke, causing repeated connection attempts).

**3. Control characters written to output box**
On startup, `getwaiting()` could receive protocol bytes (e.g. the `\x0e` setmode 
command echo) that fall through to the echoback branch. These are control 
characters below 0x20 that render as invisible/garbage in the output box. Fixed 
by only writing printable ASCII (0x20–0x7E) to the output box.

Tested on CachyOS (Arch-based) with KDE Plasma 6 / Wayland. Would appreciate 
testing on other platforms and with real K1EL hardware.