### PR TITLE
Send POTSET on host open to calibrate speed pot decoding

### DIFF
--- a/winkeyerserial/__main__.py
+++ b/winkeyerserial/__main__.py
@@ -288,6 +288,13 @@ class WinKeyer(QtWidgets.QMainWindow):
                 f"{self.device} is open but WinKeyer is not responding"
             )
         self.timer2.start(100)
+
+        # Send POTSET to configure speed pot range: min=5 WPM, range=50 WPM (5-55 WPM).
+        # Without this, the keyer uses its own default MIN_WPM which may differ from
+        # what this host assumes when decoding pot speed bytes (raw - 123 = raw - 0x80 + 5).
+        command = b"\x05\x05\x32\x00"
+        self.port.write(command)
+
         command = b"\x07"  # have the winkeyer return the pot speed setting
         self.port.write(command)
 


### PR DESCRIPTION
The WinKeyer protocol encodes speed pot bytes as:
  0x80 | (actual_wpm - MIN_WPM)

The host decodes them as:
  actual_wpm = raw_byte - 123  (equivalent to raw - 0x80 + 5, assuming MIN_WPM=5)

Without a POTSET command, the keyer uses its own stored MIN_WPM default which may differ from 5. This causes the host to calculate the wrong speed when the user adjusts the hardware speed control, resulting in the keyer being set to a different speed than intended.

Fix: send POTSET <0x05><0x05><0x32><0x00> during host_open() to explicitly configure MIN_WPM=5 and WPMRANGE=50 (range: 5-55 WPM). This ensures the keyer and host agree on the encoding, making speed pot changes decode correctly on all compliant WinKeyer v2 implementations.